### PR TITLE
Clarify warning for old gmp

### DIFF
--- a/lib/Crypto/Util/number.py
+++ b/lib/Crypto/Util/number.py
@@ -54,7 +54,10 @@ except ImportError:
 
 # You need libgmp v5 or later to get mpz_powm_sec.  Warn if it's not available.
 if _fastmath is not None and not _fastmath.HAVE_DECL_MPZ_POWM_SEC:
-    _warn("Not using mpz_powm_sec.  You should rebuild using libgmp >= 5 to avoid timing attack vulnerability.", PowmInsecureWarning)
+    _warn("mpz_powm_sec in libgmp < 5 is vulnerable to timing attacks."
+            " Using non-vulnerable pure-python fallback."
+            " Recompile pycrypto against libgmp >= 5 to use faster routines.",
+            PowmInsecureWarning)
 
 # New functions
 from _number_new import *


### PR DESCRIPTION
Fedora EPEL builds addon packages for RHEL. One package that is shipped is a forwards compat version of pycrypto-2.6.1 for RHEL6. RHEL6 is shipping with libgmp-4.x. This triggers the following warning from pycrpyto:
``` python
_warn("Not using mpz_powm_sec. You should rebuild using libgmp >= 5 to avoid timing attack vulnerability.", PowmInsecureWarning)
```

People using the library encounter this error and are concerned that pycrypto is insecure. However, reading the pycrypto code it seems that what's actually happening is that pycrypto detects the timing-attack-vulnerable version and then fallsback to a pure-python implementation that is not vulnerable. If this is the case, the warning message should be changed so that people are not mislead into thinking that pycrypto is insecure.

This pull request implements a change to the warning message.

If my analysis of the code is incorrect and the pure-python version of the code being used when gmp < 5 is insecure, please let us know so that we can figure out a solution. Thanks.

(EPEL Bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1103566 )