### PR TITLE
Don't fail if libgmp is lower than version 5

### DIFF
--- a/lib/Crypto/Util/number.py
+++ b/lib/Crypto/Util/number.py
@@ -53,7 +53,7 @@ except ImportError:
     _fastmath = None
 
 # You need libgmp v5 or later to get mpz_powm_sec.  Warn if it's not available.
-if _fastmath is not None and not _fastmath.HAVE_DECL_MPZ_POWM_SEC:
+if _fastmath is not None and (not hasattr(_fastmath, 'HAVE_DECL_MPZ_POWM_SEC') or not _fastmath.HAVE_DECL_MPZ_POWM_SEC):
     _warn("Not using mpz_powm_sec.  You should rebuild using libgmp >= 5 to avoid timing attack vulnerability.", PowmInsecureWarning)
 
 # New functions


### PR DESCRIPTION
If libgmp is installed, then _fastmath will be defined.  If libgmp is below version 5, it will not have the HAVE_DECL_MPZ_POWM_SEC attribute.  Thus, _fastmath.HAVE_DECL_MPZ_POWM_SEC will throw an error even though the desired functionality seems to be to warn the client of a timing attack vulnerability.

This change checks if _fastmath has the attribute before checking whether the attribute is truthy or falsy.