### PR TITLE
Fix exception syntax error

### DIFF
--- a/lib/Crypto/Random/OSRNG/posix.py
+++ b/lib/Crypto/Random/OSRNG/posix.py
@@ -63,7 +63,7 @@ class DevURandomRNG(BaseRNG):
         while len(data) < N:
             try:
                 d = self.__file.read(N - len(data))
-            except IOError, e:
+            except IOError as e:
                 # read(2) has been interrupted by a signal; redo the read
                 if e.errno == errno.EINTR:
                     continue


### PR DESCRIPTION
```
.tox/py34/lib/python3.4/site-packages/Crypto/Random/OSRNG/__init__.py:32: in <module>
    from Crypto.Random.OSRNG.posix import new
E     File "/Users/victorlin/workspace/bugbuzz/bugbuzz-python/.tox/py34/lib/python3.4/site-packages/Crypto/Random/OSRNG/posix.py", line 66
E       except IOError, e:
E                     ^
E   SyntaxError: invalid syntax
```