### PR TITLE
Add TravisCI config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ src/config.h
 
 # Backup files
 *~
+
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+os:
+    - linux
+
+env:
+    matrix:
+        - TOX_ENV=py26
+        - TOX_ENV=py27
+        - TOX_ENV=py33
+        - TOX_ENV=py34
+
+install:
+    - ./.travis/install.sh
+
+script:
+    - ./.travis/run.sh

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+set -x
+
+sudo add-apt-repository -y ppa:fkrull/deadsnakes
+sudo apt-get -y update
+
+sudo apt-get install python3.3 python3.3-dev
+
+sudo pip install virtualenv
+
+virtualenv ~/.venv
+source ~/.venv/bin/activate
+pip install tox coveralls

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+set -x
+
+source ~/.venv/bin/activate
+tox -e $TOX_ENV -- $TOX_FLAGS

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py26,py27,py33,py34
+
+[testenv]
+commands = {envpython} setup.py test


### PR DESCRIPTION
This PR adds a configuration for tox.ini and TravisCI. Testing is restricted to Python 2.6, 2.7, 3.3 and 3.4, which are all the Python versions supported by cryptography.