### PR TITLE
* Add cipher state serialization

### DIFF
--- a/src/ARC2.c
+++ b/src/ARC2.c
@@ -49,6 +49,9 @@
 #define KEY_SIZE 0
 #define PCT_ARC2_MODULE  /* Defined to get ARC2's additional keyword arguments */
 
+// used in block_template.c
+#define SUPPORTS_SERIALIZATION 0
+
 typedef uint32_t U32;
 typedef uint16_t U16;
 typedef uint8_t U8;
@@ -220,5 +223,16 @@ static void
 block_finalize(block_state* self)
 {
 }
+
+/* If implemented change SUPPORTS_SERIALIZATION define at top of file to 1 */
+/*
+static char* serialize_state(block_state *state, int *out_length)
+{
+}
+
+static void deserialize_state(block_state *state, char *in, int bslen)
+{
+}
+*/
 
 #include "block_template.c"

--- a/src/Blowfish.c
+++ b/src/Blowfish.c
@@ -35,6 +35,9 @@
 #define BLOCK_SIZE 8    /* 64-bit block size */
 #define KEY_SIZE 0      /* variable key size */
 
+// used in block_template.c
+#define SUPPORTS_SERIALIZATION 0
+
 #define BLOWFISH_MAGIC 0xf9d565deu
 typedef struct {
     uint32_t magic;
@@ -234,6 +237,17 @@ static void Blowfish_init(Blowfish_state *self, const unsigned char *key, int ke
 static void block_finalize(block_state *self)
 {
 }
+
+/* If implemented change SUPPORTS_SERIALIZATION define at top of file to 1 */
+/*
+static char* serialize_state(block_state *state, int *out_length)
+{
+}
+
+static void deserialize_state(block_state *state, char *in, int bslen)
+{
+}
+*/
 
 #include "block_template.c"
 

--- a/src/CAST.c
+++ b/src/CAST.c
@@ -48,6 +48,9 @@
 #define BLOCK_SIZE 8
 #define KEY_SIZE 0
 
+// used in block_template.c
+#define SUPPORTS_SERIALIZATION 0
+
 /* adjust these according to your compiler/platform. On some machines
    uint32 will have to be a long. It's OK if uint32 is more than 32 bits. */
 typedef uint32_t uint32;
@@ -454,5 +457,16 @@ static void block_decrypt(block_state *self,
 	memcpy(out, in, 8);
 	castcrypt(self, out, 1);
 }
+
+/* If implemented change SUPPORTS_SERIALIZATION define at top of file to 1 */
+/*
+static char* serialize_state(block_state *state, int *out_length)
+{
+}
+
+static void deserialize_state(block_state *state, char *in, int bslen)
+{
+}
+*/
 
 #include "block_template.c"

--- a/src/DES.c
+++ b/src/DES.c
@@ -30,6 +30,9 @@
  * assert-like LTC_ARGCHK macro fails. */
 #define ARGTYPE 4
 
+// used in block_template.c
+#define SUPPORTS_SERIALIZATION 0
+
 /* Include the actial DES implementation */
 #include "libtom/tomcrypt_des.c"
 
@@ -119,6 +122,17 @@ static void block_decrypt(block_state *self, unsigned char *in, unsigned char *o
 #endif
     assert(rc == CRYPT_OK);
 }
+
+/* If implemented change SUPPORTS_SERIALIZATION define at top of file to 1 */
+/*
+static char* serialize_state(block_state *state, int *out_length)
+{
+}
+
+static void deserialize_state(block_state *state, char *in, int bslen)
+{
+}
+*/
 
 #ifdef PCT_DES3_MODULE
 # define MODULE_NAME _DES3   /* triple DES */


### PR DESCRIPTION
I have an unusual use case: I'm writing a scalable server with Twisted for an existing client that I can't modify. This client uses AES in MODE_CFB to secure it's communication with the server.

To have CPU concurrency I've decided to have a main process listen on the port as a sort of load balancer and distribute connections out by sending the socket file descriptor over a UNIX socket to be re-opened in the subprocess. I realize I could share the main port and listen across all the subprocesses, but for protocol specific reasons this is very undesirable. I'll spare the details for now since it's not strictly necessary to explain what I'm doing--

Passing the socket descriptors is easy enough, but encryption has already started by the time I've done this, so I have to somehow re-open the CFB cipher in the subprocess and resume reading the stream. In theory I could just pass the `cipher._cipher.IV` in and reopen it, but that didn't actually work, I believe because AES calls rijndaelKeySetupEnc on block_init and causes the IV to change.

Pre-emptively: I could also accomplish this by forking or with shared memory, but the former doesn't work because the subprocesses are long running and new connections would be opened after the fork occurs. The latter is undesirable simply because I've never tried to used shared memory in Python and I would be less sure how to reliably make it play nice with PyCrypto.

As a proof of concept I wrote serialization/deserialization methods and tested them in my application. This worked flawlessly, allowing me to pass the socket file descriptor and CFB cipher to the subprocess, picking up the protocol where the main process left off.

I'm hoping you'll either accept this pull request to make my life easier (I don't want to have to patch PyCrypto on every server this is deployed on), or propose a better way to handle this. Thanks in advance.

Short test/example code here: https://gist.github.com/avosirenfal/482787bf2b497fd1ac0a