### PR TITLE
WIP: Avoids defining prototypes on Windows

### DIFF
--- a/src/libtom/tomcrypt.h
+++ b/src/libtom/tomcrypt.h
@@ -63,6 +63,10 @@ enum {
    CRYPT_PK_INVALID_PADDING /* Invalid padding on input */
 };
 
+#ifdef _WIN32
+   #define LTC_NO_PROTOTYPES
+#endif
+
 #include <tomcrypt_cfg.h>
 #include <tomcrypt_macros.h>
 #include <tomcrypt_cipher.h>


### PR DESCRIPTION
Fixes https://github.com/dlitz/pycrypto/issues/167

Based on this [suggestion]( https://github.com/dlitz/pycrypto/issues/167#issuecomment-183773231 ) by @nitetrain8, this defines `LTC_NO_PROTOTYPES` before including `tomcrypt_cfg.h`. Not sure if this is needed for other platforms than Windows so have placed this in an `ifdef` statement to restrict. Feedback welcome. Please try and feel free to let me know if it works ok.

cc @cbogithub @nitetrain8 @MartyMacGyver