### PR TITLE
Blowfish does not limit the key length

### DIFF
--- a/src/Blowfish.c
+++ b/src/Blowfish.c
@@ -174,9 +174,6 @@ static void Blowfish_init(Blowfish_state *self, const unsigned char *key, int ke
     if (keylen < 1) {
         PyErr_SetString(PyExc_ValueError, "Key cannot be empty");
         return;
-    } else if (keylen > 56) {
-        PyErr_SetString(PyExc_ValueError, "Maximum key size is 448 bits");
-        return;
     }
 
     /* Initialize the P-array with the digits of Pi, and XOR it with the key */


### PR DESCRIPTION
Though keys longer than the limit have no positive effect on security, it sometimes interferes with other implementations using longer keys