### PR TITLE
Adds a static replacement function via an include file (src/rpl_mallo…

### DIFF
--- a/src/block_template.c
+++ b/src/block_template.c
@@ -25,6 +25,13 @@
  */
 
 #include "pycrypto_common.h"
+
+#ifdef HAVE_MALLOC
+#if HAVE_MALLOC == 0
+#include "rpl_malloc.h"
+#endif
+#endif
+
 #include "modsupport.h"
 #include <string.h>
 #include "_counter.h"

--- a/src/rpl_malloc.h
+++ b/src/rpl_malloc.h
@@ -1,0 +1,35 @@
+/*
+ * added to provide rpl_malloc() when GNU MALLOC
+ * RATHER than as a AC_LIBOBJ replacement
+ * Note also: rpl_malloc, not being previously defined
+ * and without prototype was being seen as a function
+ * that returns an int rather than as unsigned char *
+ */
+#ifdef HAVE_MALLOC
+#if HAVE_MALLOC == 0
+#undef malloc
+#include <malloc.h>
+#ifdef _AIX
+#include <sys/malloc.h>
+#endif
+
+     /*
+      * Allocate an N-byte block of memory from the heap.
+      * If N is zero, allocate a 1-byte block.
+      * static because block_template.c may be included several times
+      */
+
+     static void *
+     rpl_malloc (size_t n)
+     {
+       if (n == 0)
+         n = 1;
+       return (void *) malloc (n);
+     }
+/*
+ * restore definition of malloc to rpl_malloc for code below
+ */
+#define malloc rpl_malloc
+#endif
+#endif
+

--- a/src/stream_template.c
+++ b/src/stream_template.c
@@ -25,6 +25,13 @@
  */
 
 #include "pycrypto_common.h"
+
+#ifdef HAVE_MALLOC
+#if HAVE_MALLOC == 0
+#include "rpl_malloc.h"
+#endif
+#endif
+
 #include "modsupport.h"
 
 #define _STR(x) #x


### PR DESCRIPTION
…c.h) in src/block_template.c

and src/stream_template.c

This concludes part 1 of of issue #209

I expect using an ac.get() call in setup.py to check the value of
to add src/rpl_malloc.c to the sources to be compiled
rather than as a static function that is included multiple times.
However, this seems to fit in the style of how src/*_template.c files
are included in the main files.
