### PR TITLE
Fixed example code in comments

### DIFF
--- a/lib/Crypto/Signature/PKCS1_PSS.py
+++ b/lib/Crypto/Signature/PKCS1_PSS.py
@@ -31,7 +31,7 @@ this:
 
     >>> from Crypto.Signature import PKCS1_PSS
     >>> from Crypto.Hash import SHA1
-    >>> from Crypto.PublicKey import RSA1
+    >>> from Crypto.PublicKey import RSA
     >>> from Crypto import Random
     >>>
     >>> message = 'To be signed'


### PR DESCRIPTION
There was a slight error in the example code in the comment for a PSS signature.