### PR TITLE
Backport of fix for CVE-2018-6594 from pycryptodome

### DIFF
--- a/lib/Crypto/PublicKey/ElGamal.py
+++ b/lib/Crypto/PublicKey/ElGamal.py
@@ -154,33 +154,33 @@ def generate(bits, randfunc, progress_func=None):
         if number.isPrime(obj.p, randfunc=randfunc):
             break
     # Generate generator g
-    # See Algorithm 4.80 in Handbook of Applied Cryptography
-    # Note that the order of the group is n=p-1=2q, where q is prime
     if progress_func:
         progress_func('g\n')
     while 1:
+        # Choose a square residue; it will generate a cyclic group of order q.
+        obj.g = pow(number.getRandomRange(2, obj.p, randfunc), 2, obj.p)
+
         # We must avoid g=2 because of Bleichenbacher's attack described
         # in "Generating ElGamal signatures without knowning the secret key",
         # 1996
-        #
-        obj.g = number.getRandomRange(3, obj.p, randfunc)
-        safe = 1
-        if pow(obj.g, 2, obj.p)==1:
-            safe=0
-        if safe and pow(obj.g, q, obj.p)==1:
-            safe=0
+        if obj.g in (1, 2):
+            continue
+
         # Discard g if it divides p-1 because of the attack described
         # in Note 11.67 (iii) in HAC
-        if safe and divmod(obj.p-1, obj.g)[1]==0:
-            safe=0
+        if (obj.p - 1) % obj.g == 0:
+            continue
+
         # g^{-1} must not divide p-1 because of Khadir's attack
         # described in "Conditions of the generator for forging ElGamal
         # signature", 2011
         ginv = number.inverse(obj.g, obj.p)
-        if safe and divmod(obj.p-1, ginv)[1]==0:
-            safe=0
-        if safe:
-            break
+        if (obj.p - 1) % ginv == 0:
+            continue
+
+        # Found
+        break
+
     # Generate private key x
     if progress_func:
         progress_func('x\n')


### PR DESCRIPTION
When creating ElGamal keys, the generator wasn't a square residue: ElGamal
encryption done with those keys cannot be secure under the DDH assumption.

More details:
- https://github.com/TElgamal/attack-on-pycrypto-elgamal
- https://github.com/Legrandin/pycryptodome/issues/90
- https://github.com/dlitz/pycrypto/issues/253

This commit is a backport to pycrypto of Legrandin/pycryptodome@99c27a3b
Thanks to Weikeng Chen.

Hopefully I've not done something stupid here; I'm no mathematician or cryptographer, I've just attempted to map the changes made in pycryptodome back to pycrypto.