### PR TITLE
Remove deprecated time.clock()

### DIFF
--- a/lib/Crypto/Random/_UserFriendlyRNG.py
+++ b/lib/Crypto/Random/_UserFriendlyRNG.py
@@ -73,8 +73,8 @@ class _EntropyCollector(object):
         t = time.time()
         self._time_es.feed(struct.pack("@I", int(2**30 * (t - floor(t)))))
 
-        # Add the fractional part of time.clock()
-        t = time.clock()
+        # Add the fractional part of time.process_time()
+        t = time.process_time()
         self._clock_es.feed(struct.pack("@I", int(2**30 * (t - floor(t)))))
 
 


### PR DESCRIPTION
/Crypto/Random/_UserFriendlyRNG.py:77: DeprecationWarning: time.clock has been deprecated in Python 3.3 and will be removed from Python 3.8: use time.perf_counter or time.process_time instead