### PR TITLE
Replaced `time.clock()` with `time.process_time()`

### DIFF
--- a/lib/Crypto/Random/_UserFriendlyRNG.py
+++ b/lib/Crypto/Random/_UserFriendlyRNG.py
@@ -73,8 +73,8 @@ class _EntropyCollector(object):
         t = time.time()
         self._time_es.feed(struct.pack("@I", int(2**30 * (t - floor(t)))))
 
-        # Add the fractional part of time.clock()
-        t = time.clock()
+        # Add the fractional part of time.process_time()
+        t = time.process_time()
         self._clock_es.feed(struct.pack("@I", int(2**30 * (t - floor(t)))))
 
 


### PR DESCRIPTION
(time clock was flagged as deprecated in Python 3.3 and got removed in Python 3.8)

Fixes https://github.com/dlitz/pycrypto/issues/283